### PR TITLE
use compat for isapple

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,6 @@
 module BuildBlink
 # put into module b/c some globals are defined in install.jl
+using Compat.Sys: isapple
 
 include(joinpath(@__DIR__, "../src/AtomShell/install.jl"))
 


### PR DESCRIPTION
fixes a build error.

```julia
(blink) pkg> build Blink
  Building MbedTLS ───→ `~/.julia/packages/MbedTLS/Qo8T/deps/build.log`
  Building WebIO ─────→ `~/.julia/packages/WebIO/VAWbO/deps/build.log`
  Building HttpParser → `~/.julia/packages/HttpParser/yGK3/deps/build.log`
  Building Blink ─────→ `~/.julia/dev/Blink/deps/build.log`
 Resolving package versions...
┌ Error: Error building `Blink`: 
│ ┌ Warning: Could not load Revise.
│ └ @ Main ~/.julia/config/startup.jl:14
│ ERROR: LoadError: LoadError: LoadError: UndefVarError: isapple not defined
│ Stacktrace:
│  [1] top-level scope at none:0
│  [2] eval at ./boot.jl:319 [inlined]
│  [3] @static(::LineNumberNode, ::Module, ::Any) at ./osutils.jl:19
│  [4] include at ./boot.jl:317 [inlined]
│  [5] include_relative(::Module, ::String) at ./loading.jl:1038
│  [6] include at ./sysimg.jl:29 [inlined]
│  [7] include(::String) at /Users/benacland/.julia/dev/Blink/deps/build.jl:1
│  [8] top-level scope at none:0
│  [9] include at ./boot.jl:317 [inlined]
│  [10] include_relative(::Module, ::String) at ./loading.jl:1038
│  [11] include(::Module, ::String) at ./sysimg.jl:29
│  [12] include(::String) at ./client.jl:398
│  [13] top-level scope at none:0
│ in expression starting at /Users/benacland/.julia/dev/Blink/src/AtomShell/install.jl:9
│ in expression starting at /Users/benacland/.julia/dev/Blink/src/AtomShell/install.jl:9
│ in expression starting at /Users/benacland/.julia/dev/Blink/deps/build.jl:5
```